### PR TITLE
fix: Resolve issue in resolving imports of other scripts

### DIFF
--- a/src/BMCodeHost.ide.js
+++ b/src/BMCodeHost.ide.js
@@ -604,7 +604,7 @@ class MyClass extends TypescriptWidget {
 	 * @param targetArray <[Object]>		An array to which the exportable widgets will be added.
 	 */
 	function findExportsInWidget(rootWidget, targetArray) {
-		if (rootWidget.Properties.Type == 'BMCodeHost' || rootWidget.Properties.Type == 'BMTypescriptHost' || rootWidget.properties.Type == 'BMTypescriptClassHost') {
+		if (rootWidget.Properties.Type == 'BMCodeHost' || rootWidget.Properties.Type == 'BMTypescriptHost' || rootWidget.Properties.Type == 'BMTypescriptClassHost') {
 			targetArray.push({
 				title: rootWidget.Properties.Title,
 				exports: rootWidget.Properties.Exports,


### PR DESCRIPTION
Because of the typo introduced when adding support for the Typescript class, this was crashing and faling to resolve