### PR TITLE
Fix number basetype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.8.5
+
+Resolves an issue where the `NUMBER` base type was declared as `string` instead of `number`.
+
+## Typescript Class
+
+When a significant number of properties are deleted, a confirmation window will be displayed with an option to retain the bindings for those properties. When these bindings are retained, they must be removed one by one from the composer if any aren't needed anymore.
+
 # 2.8.3
 
 Resolves an issue that could cause an error to appear in the browser console.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "bm-code-host",
     "packageName": "BMCodeHost",
     "moduleName": "BMCodeHost",
-    "version": "2.8.3",
+    "version": "2.8.5",
     "description": "Allows customizing mashups using CSS and JavaScript code.",
     "thingworxServer": "http://localhost",
     "thingworxUser": "Administrator",

--- a/src/Thingworx.d.ts
+++ b/src/Thingworx.d.ts
@@ -2101,7 +2101,7 @@ declare interface JSONInfoTable<T> {
 
 type NOTHING = void;
 type STRING = string;
-type NUMBER = string;
+type NUMBER = number;
 type BOOLEAN = boolean;
 
 type ANYSCALAR = unknown;


### PR DESCRIPTION
Resolves an issue where the `NUMBER` base type was declared as `string` instead of `number`.

## Typescript Class

When a significant number of properties are deleted, a confirmation window will be displayed with an option to retain the bindings for those properties. When these bindings are retained, they must be removed one by one from the composer if any aren't needed anymore.