### PR TITLE
2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2.8.5
+# 2.9
 
 Resolves an issue where the `NUMBER` base type was declared as `string` instead of `number`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.8.5
+
+Resolves an issue where the `NUMBER` base type was declared as `string` instead of `number`.
+
+## Typescript Class
+
+When a significant number of properties are deleted, a confirmation window will be displayed with an option to retain the bindings for those properties. When these bindings are retained, they must be removed one by one from the composer if any aren't needed anymore.
+
 # 2.8.3
 
 Resolves an issue that could cause an error to appear in the browser console.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "bm-code-host",
     "packageName": "BMCodeHost",
     "moduleName": "BMCodeHost",
-    "version": "2.8.5",
+    "version": "2.9.0",
     "description": "Allows customizing mashups using CSS and JavaScript code.",
     "thingworxServer": "http://localhost",
     "thingworxUser": "Administrator",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "bm-code-host",
     "packageName": "BMCodeHost",
     "moduleName": "BMCodeHost",
-    "version": "2.8.3",
+    "version": "2.8.5",
     "description": "Allows customizing mashups using CSS and JavaScript code.",
     "thingworxServer": "http://localhost",
     "thingworxUser": "Administrator",

--- a/src/TWRuntimeWidget.d.ts
+++ b/src/TWRuntimeWidget.d.ts
@@ -27,12 +27,12 @@ declare class TWRuntimePropertyAspect {
 /**
  * An aspect that makes the property it's applied to a binding source at design time.
  */
-const bindingSource: TWRuntimePropertyAspect;
+declare const bindingSource: TWRuntimePropertyAspect;
 
 /**
  * An aspect that makes the property it's applied to a binding target at design time.
  */
-const bindingTarget: TWRuntimePropertyAspect;
+declare const bindingTarget: TWRuntimePropertyAspect;
 
 /**
  * Constructs and returns a property aspect that can be used to 
@@ -46,7 +46,7 @@ const bindingTarget: TWRuntimePropertyAspect;
  * @param {string} name         The name of the method that will handle this.
  * @return {TWPropertyAspect}   A property aspect.
  */
-function canBind(name: string): TWRuntimePropertyAspect;
+declare function canBind(name: string): TWRuntimePropertyAspect;
 
 /**
  * Constructs and returns a property aspect that can be used to 
@@ -63,7 +63,7 @@ function canBind(name: string): TWRuntimePropertyAspect;
  * @param {string} name         The name of the method that will handle this.
  * @return {TWPropertyAspect}   A property aspect.
  */
-function didBind(name: string): TWRuntimePropertyAspect;
+declare function didBind(name: string): TWRuntimePropertyAspect;
 
 /**
  * Constructs and returns a property aspect that specifies what infotable the widget
@@ -72,7 +72,7 @@ function didBind(name: string): TWRuntimePropertyAspect;
  * @param {string} name                         The name of the infotable property.
  * @return {TWSourceInfotablePropertyAspect}    A property aspect.
  */
-function sourcePropertyName(name: string): TWRuntimePropertyAspect;
+declare function sourcePropertyName(name: string): TWRuntimePropertyAspect;
 
 /**
  * Constructs and returns a property aspect that specifies what infotable
@@ -81,37 +81,37 @@ function sourcePropertyName(name: string): TWRuntimePropertyAspect;
  * @param {string} name         The name of the infotable property.
  * @return {TWPropertyAspect}   A property aspect.
  */
-function baseTypeInfotableProperty(name: string): TWRuntimePropertyAspect;
+declare function baseTypeInfotableProperty(name: string): TWRuntimePropertyAspect;
 
 /**
  * Returns a decorator that binds the class member it is applied to to a property definition.
  * @param  {...TWRuntimePropertyAspect} args        An optional list of property aspects to apply to this property.
  * @return {any}                                    A decorator.
  */
-function property(...args: TWRuntimePropertyAspect[]): <T extends TWRuntimeWidget, K extends NonMethod<T>, V>(target: T, key: K, descriptor?: V extends (...args: any[]) => any ? never : V) => void;
+declare function property(...args: TWRuntimePropertyAspect[]): <T extends TWRuntimeWidget, K extends NonMethod<T>, V>(target: T, key: K, descriptor?: V extends (...args: any[]) => any ? never : V) => void;
 
 /**
  * Binds the class member it is applied to to the a property.
  */
-function property<T extends TWRuntimeWidget, K extends NonMethod<T>, V>(target: T, key: K, descriptor?: V extends (...args: any[]) => any ? never : V): void;
+declare function property<T extends TWRuntimeWidget, K extends NonMethod<T>, V>(target: T, key: K, descriptor?: V extends (...args: any[]) => any ? never : V): void;
 
 /**
  * A decorator that binds the given property to the service with the same name as the method.
  */
-function service<T extends TWRuntimeWidget, K extends keyof T, F extends T[K]>(target: T, key: CompatibleKeys<T, (...args: any[]) => any>, descriptor?: TypedPropertyDescriptor<(...args: any[]) => any>): void;
+declare function service<T extends TWRuntimeWidget, K extends keyof T, F extends T[K]>(target: T, key: CompatibleKeys<T, (...args: any[]) => any>, descriptor?: TypedPropertyDescriptor<(...args: any[]) => any>): void;
 
 /**
  * A decorator that marks the given property as an event.
  */
-const event: <T extends TWRuntimeWidget, K extends keyof T, F extends T[K]>(target: T, key: CompatibleKeys<T, TWEvent>, descriptor?: TypedPropertyDescriptor<TWEvent>) => void;
+declare const event: <T extends TWRuntimeWidget, K extends keyof T, F extends T[K]>(target: T, key: CompatibleKeys<T, TWEvent>, descriptor?: TypedPropertyDescriptor<TWEvent>) => void;
 
 /**
  * A decorator that marks the given property as an event.
  */
-const twevent: <T extends TWRuntimeWidget, K extends keyof T, F extends T[K]>(target: T, key: CompatibleKeys<T, TWEvent>, descriptor?: TypedPropertyDescriptor<TWEvent>) => void;
+declare const twevent: <T extends TWRuntimeWidget, K extends keyof T, F extends T[K]>(target: T, key: CompatibleKeys<T, TWEvent>, descriptor?: TypedPropertyDescriptor<TWEvent>) => void;
 
 /**
 * A decorator that makes a given widget class available to Thingworx.
 * @param widget     The widget the decorator is applied to.
 */
-function TWWidgetDefinition<T extends new(...args: {}[]) => TWRuntimeWidget>(widget: T): void;
+declare function TWWidgetDefinition<T extends new(...args: {}[]) => TWRuntimeWidget>(widget: T): void;

--- a/src/Thingworx.d.ts
+++ b/src/Thingworx.d.ts
@@ -2095,7 +2095,7 @@ declare interface FieldDefinitionBase<key extends string, T = any> extends Field
 declare interface JSONInfoTable<T> {
     rows: T[];
     dataShape: {
-        fieldDefinitions: {[key in keyof T]: FieldDefinitionBase<key, T[key]>}
+        fieldDefinitions: {[key in keyof T]: key extends string ? FieldDefinitionBase<key, T[key]> : never}
     }
 }
 
@@ -2177,7 +2177,7 @@ type THINGNAME<Template extends string | undefined = undefined, Shape extends st
  * A subclass of `TWRuntimeWidgets` that provides support for widget classes that can be defined using
  * the `BMCodeHost` extensions.
  */
- declare class TypescriptWidget extends TWRuntimeWidget {
+ declare abstract class TypescriptWidget extends TWRuntimeWidget {
     renderHtml(): string;
     afterRender(): void;
 

--- a/src/Thingworx.d.ts
+++ b/src/Thingworx.d.ts
@@ -2101,7 +2101,7 @@ declare interface JSONInfoTable<T> {
 
 type NOTHING = void;
 type STRING = string;
-type NUMBER = string;
+type NUMBER = number;
 type BOOLEAN = boolean;
 
 type ANYSCALAR = unknown;


### PR DESCRIPTION
Resolves an issue where the `NUMBER` base type was declared as `string` instead of `number`.

## Typescript Class

When a significant number of properties are deleted, a confirmation window will be displayed with an option to retain the bindings for those properties. When these bindings are retained, they must be removed one by one from the composer if any aren't needed anymore.